### PR TITLE
Fixes docker build failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ WORKDIR		$HOME
 
 RUN			pip install cython==0.15
 RUN			pip install louie
+RUN			pip install gevent
 RUN			pip install flask-socketio
 
 ################################################################################


### PR DESCRIPTION
Fixes missing gevent pip install preventing the docker build from completing. 
This resolved issue #1.
